### PR TITLE
aarch64 and lsio migration

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine as builder
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+RUN \
+    mkdir workdir && \
+    cd workdir && \
+    git clone https://github.com/jellyfin/jellyfin.git && \
+    cd jellyfin && \
+    dotnet publish Jellyfin.Server --configuration Release --self-contained --runtime linux-musl-arm64 --output /jellyfin -p:DebugSymbols=false -p:DebugType=none -p:UseAppHost=true
+
+FROM jellyfin/jellyfin as web
+FROM alpine
+
+RUN \
+apk --no-cache add ffmpeg catatonit bash procps icu && \
+apk --no-cache --virtual add wget && \
+mkdir -p \
+/opt/jellyfin /data/data data/cache data/config data/log && \
+cd / && \
+wget https://raw.githubusercontent.com/sevenrats/signalproxy.sh/main/signalproxy.sh && \
+rm -rf \
+    /tmp/* /var/cache \
+    /opt/jellyfin/jellyfin_10.8.8_amd64-musl.tar.gz
+
+COPY --from=builder /jellyfin /opt/jellyfin/jellyfin
+COPY --from=web /jellyfin/jellyfin-web /opt/jellyfin/jellyfin/jellyfin-web
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["catatonit", "/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   vpn:
-    image: jellyfin:alpine
+    image: jellyfin
     container_name: jellyfin
     security_opt:
       - no-new-privileges:true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,16 @@ JELLYFINDIR="/opt/jellyfin"
 FFMPEGDIR="/usr/share/jellyfin-ffmpeg"
 DATADIR="/data/jellyfin"
 
+  # support migration from lsio
+if [ -d "/config" ]; then
+  ln -sf /config/log $DATADIR/log
+  ln -sf /config/cache $DATADIR/cache
+  ln -sf /config/data $DATADIR/data
+  find /config -maxdepth 1 -not \
+    \( -wholename "/data" -o -wholename "/cache" -o -wholename "/log" -o -wholename "/config" \)\
+    -exec ln -sf {} $DATADIR/config \;
+fi
+
 # Launch App
   $JELLYFINDIR/jellyfin/jellyfin \
   -d $DATADIR/data \


### PR DESCRIPTION
support aarch64 by building unstable from source (required localizations are not part of any release yet)
attempt to support lsio migration by checking for their config directory and linking it to ours.
fixes #4 
fixes #6 